### PR TITLE
Avoid overwriting the builder :latest tag

### DIFF
--- a/.travis/push-to-dockerhub.sh
+++ b/.travis/push-to-dockerhub.sh
@@ -10,6 +10,7 @@ CI_TAG="${version}-ci-${id}"
 
 docker tag projectriff/builder:latest projectriff/builder:${version}
 docker tag projectriff/builder:latest projectriff/builder:${CI_TAG}
+docker rmi projectriff/builder:latest
 
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 docker push projectriff/builder


### PR DESCRIPTION
Many riff install are currently configured to automatically pull the
latest builder image. #17 introduces a backwards incompatible change
that should not be rolled out automatically to all users.

This change preserves pushing the versioned and ci snapshot tags.