### PR TITLE
Make local testing of function buildpacks easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build test grab-run-image
+.PHONY: build build-dev test grab-run-image
 
 build:
 	pack create-builder -b builder.toml projectriff/builder
+
+build-dev:
+	pack create-builder -b builder-dev.toml projectriff/builder
 
 test: grab-run-image
 	cd integration-tests && GO111MODULE=on go run main.go

--- a/builder-dev.toml
+++ b/builder-dev.toml
@@ -1,0 +1,36 @@
+buildpacks = [
+  { id = "io.projectriff.java",                latest = true, uri = "../java-function-buildpack/artifactory/io/projectriff/java/io.projectriff.java/latest" },
+  { id = "io.projectriff.node",                latest = true, uri = "../node-function-buildpack/artifactory/io/projectriff/node/io.projectriff.node/latest" },
+  { id = "io.projectriff.command",             latest = true, uri = "../command-function-buildpack/artifactory/io/projectriff/command/io.projectriff.command/latest" },
+  { id = "org.cloudfoundry.openjdk",           latest = true, uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/openjdk/org.cloudfoundry.openjdk/1.0.0-M7/org.cloudfoundry.openjdk-1.0.0-M7.tgz" },
+  { id = "org.cloudfoundry.buildsystem",       latest = true, uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/buildsystem/org.cloudfoundry.buildsystem/1.0.0-M7/org.cloudfoundry.buildsystem-1.0.0-M7.tgz" },
+  { id = "org.cloudfoundry.buildpacks.nodejs", latest = true, uri = "https://github.com/cloudfoundry/nodejs-cnb/releases/download/v0.0.8/nodejs-cnb-0.0.8.tgz" },
+  { id = "org.cloudfoundry.buildpacks.npm",    latest = true, uri = "https://github.com/cloudfoundry/npm-cnb/releases/download/v0.0.7/npm-cnb-0.0.7.tgz" },
+]
+
+[[groups]]
+  # java functions
+  buildpacks = [
+    { id = "org.cloudfoundry.openjdk",     optional = true },
+    { id = "org.cloudfoundry.buildsystem", optional = true },
+    { id = "io.projectriff.java" },
+  ]
+
+[[groups]]
+  # node functions
+  buildpacks = [
+    { id = "org.cloudfoundry.buildpacks.nodejs", optional = true },
+    { id = "org.cloudfoundry.buildpacks.npm",    optional = true },
+    { id = "io.projectriff.node" },
+  ]
+
+[[groups]]
+  # command functions
+  buildpacks = [
+    { id = "io.projectriff.command" },
+  ]
+
+[stack]
+  id = "io.buildpacks.stacks.bionic"
+  build-image = "packs/build:0.1.0"
+  run-image = "packs/run:0.1.0"


### PR DESCRIPTION
The builder.toml is able to accept a local tgz for a buildpack. We can
reduce local development friction to point at local builds for
function buildpacks that are cloned and built on the developers machine.

This is only a convenience for development and should never be used to
ship a builder image.