### PR TITLE
Link version to latest ci builds

### DIFF
--- a/.travis/push-buildtemplate-to-gcs.sh
+++ b/.travis/push-buildtemplate-to-gcs.sh
@@ -5,6 +5,7 @@ set -o nounset
 set -o pipefail
 
 version=`cat VERSION`
+branch="${TRAVIS_BRANCH}"
 id=`docker image inspect projectriff/builder --format '{{.Id}}' | awk '{print substr($1, 8, 12)}'`
 CI_TAG="${version}-ci-${id}"
 
@@ -22,3 +23,12 @@ gsutil cp -a public-read riff-function-clusterbuildtemplate-${CI_TAG}.yaml gs://
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-${CI_TAG}.yaml
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-${version}.yaml
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate.yaml
+
+# update version references
+gsutil cp -h 'Content-Type: text/plain' -h 'Cache-Control: private' -a public-read <(echo "${CI_TAG}") gs://projectriff/riff-buildtemplate/versions/builds/${branch}
+gsutil cp -h 'Content-Type: text/plain' -h 'Cache-Control: private' -a public-read <(echo "${CI_TAG}") gs://projectriff/riff-buildtemplate/versions/builds/${version}
+if [[ ${version} != *"-snapshot" ]] ; then
+  gsutil cp -h 'Content-Type: text/plain' -h 'Cache-Control: private' -a public-read <(echo "${CI_TAG}") gs://projectriff/riff-buildtemplate/versions/releases/${branch}
+  # avoids overwriting existing values
+  gsutil cp -n -h 'Content-Type: text/plain' -h 'Cache-Control: private' -a public-read <(echo "${CI_TAG}") gs://projectriff/riff-buildtemplate/versions/releases/${version}
+fi


### PR DESCRIPTION
Make it easier for consumers to lock to specific builds while also
being able to track the latest builds for a given version. The CI build
number is published along side releases. There are

The latest build is referenced by branch name:
gs://projectriff/riff-buildtemplate/versions/builds/{branch}

The latest build for a given version is referenced by:
gs://projectriff/riff-buildtemplate/versions/builds/{version}

The latest release for a branch:
gs://projectriff/riff-buildtemplate/versions/releases/{branch}

The latest release for a given version (will never mutate):
gs://projectriff/riff-buildtemplate/versions/releases/{version}