### PR TITLE
Pin function buildpack versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-dev test grab-run-image
+.PHONY: build build-dev test grab-run-image templates
 
 build:
 	pack create-builder -b builder.toml projectriff/builder
@@ -13,3 +13,5 @@ grab-run-image:
 	docker pull cnbs/build
 	docker pull cnbs/run
 
+templates:
+	./apply-template.sh builder.toml.tpl builder.toml

--- a/apply-template.sh
+++ b/apply-template.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+template=${1}
+output=${2}
+
+if [ -f $template ] ; then
+  rm  $output
+  while IFS= read -r line
+  do
+    eval "echo \"$(echo "$line" | sed -e 's|"|\\"|g')\" >> $output"
+  done < "$template"
+fi

--- a/apply-template.sh
+++ b/apply-template.sh
@@ -9,6 +9,7 @@ output=${2}
 
 if [ -f $template ] ; then
   rm  $output
+  echo "# DO NOT EDIT - this file is the output of the '$template' template " >> $output
   while IFS= read -r line
   do
     eval "echo \"$(echo "$line" | sed -e 's|"|\\"|g')\" >> $output"

--- a/builder.toml
+++ b/builder.toml
@@ -1,3 +1,4 @@
+# DO NOT EDIT - this file is the output of the 'builder.toml.tpl' template 
 buildpacks = [
   { id = "io.projectriff.java",          latest = true, uri = "https://storage.googleapis.com/projectriff/java-function-buildpack/io.projectriff.java-0.1.5-BUILD-SNAPSHOT-20190722192419-3dd9e2019b5b46c1.tgz" },
   { id = "io.projectriff.node",          latest = true, uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-0.1.1-BUILD-SNAPSHOT-20190722192400-f433406d8bb38ed8.tgz" },

--- a/builder.toml.tpl
+++ b/builder.toml.tpl
@@ -1,7 +1,7 @@
 buildpacks = [
-  { id = "io.projectriff.java",          latest = true, uri = "https://storage.googleapis.com/projectriff/java-function-buildpack/io.projectriff.java-0.1.5-BUILD-SNAPSHOT-20190722192419-3dd9e2019b5b46c1.tgz" },
-  { id = "io.projectriff.node",          latest = true, uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-0.1.1-BUILD-SNAPSHOT-20190722192400-f433406d8bb38ed8.tgz" },
-  { id = "io.projectriff.command",       latest = true, uri = "https://storage.googleapis.com/projectriff/command-function-buildpack/io.projectriff.command-0.0.9-BUILD-SNAPSHOT-20190722192335-b20f223b1ec44465.tgz" },
+  { id = "io.projectriff.java",          latest = true, uri = "https://storage.googleapis.com/projectriff/java-function-buildpack/io.projectriff.java-$(curl -s https://storage.googleapis.com/projectriff/java-function-buildpack/versions/snapshots/master).tgz" },
+  { id = "io.projectriff.node",          latest = true, uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-$(curl -s https://storage.googleapis.com/projectriff/node-function-buildpack/versions/snapshots/master).tgz" },
+  { id = "io.projectriff.command",       latest = true, uri = "https://storage.googleapis.com/projectriff/command-function-buildpack/io.projectriff.command-$(curl -s https://storage.googleapis.com/projectriff/command-function-buildpack/versions/snapshots/master).tgz" },
   { id = "org.cloudfoundry.openjdk",     latest = true, uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/openjdk/org.cloudfoundry.openjdk/1.0.0-M9/org.cloudfoundry.openjdk-1.0.0-M9.tgz" },
   { id = "org.cloudfoundry.buildsystem", latest = true, uri = "https://repo.spring.io/libs-milestone-local/org/cloudfoundry/buildsystem/org.cloudfoundry.buildsystem/1.0.0-M9/org.cloudfoundry.buildsystem-1.0.0-M9.tgz" },
   { id = "org.cloudfoundry.node-engine", latest = true, uri = "https://github.com/cloudfoundry/node-engine-cnb/releases/download/v0.0.16/node-engine-cnb-0.0.16.tgz" },


### PR DESCRIPTION
By pinning the version of the function buildpacks we consume, we can
ensure reproducible builds if we need to patch a single buildpack.

The builder.toml file is templated and can be applied by running:

    make templates

The template loads and applies the latest built version. The output of
the template should be committed.

In the future, a CD process could resolve the template and open a PR
when the output changes.