### PR TITLE
Publish kpack clusterbuilders for applications and functions

### DIFF
--- a/.travis/push-buildtemplate-to-gcs.sh
+++ b/.travis/push-buildtemplate-to-gcs.sh
@@ -15,6 +15,7 @@ gcloud auth activate-service-account --key-file <(echo $GCLOUD_CLIENT_SECRET | b
 # function build template
 echo "Publish function builder"
 
+## knative build (deprecated)
 sed "s|projectriff/builder:latest|projectriff/builder:${slug}|" riff-function-clusterbuildtemplate.yaml > riff-function-clusterbuildtemplate-${slug}.yaml
 sed "s|projectriff/builder:latest|projectriff/builder:${version}|" riff-function-clusterbuildtemplate.yaml > riff-function-clusterbuildtemplate-${version}.yaml
 
@@ -22,12 +23,26 @@ gsutil cp -a public-read riff-function-clusterbuildtemplate-${slug}.yaml gs://pr
 gsutil cp -a public-read riff-function-clusterbuildtemplate-${version}.yaml gs://projectriff/riff-buildtemplate/
 gsutil cp -a public-read riff-function-clusterbuildtemplate-${slug}.yaml gs://projectriff/riff-buildtemplate/riff-function-clusterbuildtemplate.yaml
 
+## kpack
+sed "s|projectriff/builder:latest|projectriff/builder:${slug}|" riff-function-clusterbuilder.yaml > riff-function-clusterbuilder-${slug}.yaml
+sed "s|projectriff/builder:latest|projectriff/builder:${version}|" riff-function-clusterbuilder.yaml > riff-function-clusterbuilder-${version}.yaml
+
+gsutil cp -a public-read riff-function-clusterbuilder-${slug}.yaml gs://projectriff/riff-buildtemplate/
+gsutil cp -a public-read riff-function-clusterbuilder-${version}.yaml gs://projectriff/riff-buildtemplate/
+gsutil cp -a public-read riff-function-clusterbuilder-${slug}.yaml gs://projectriff/riff-buildtemplate/riff-function-clusterbuilder.yaml
+
 # application build template
 echo "Publish application builder"
 
+## knative build (deprecated)
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-${slug}.yaml
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate-${version}.yaml
 gsutil cp -a public-read riff-application-clusterbuildtemplate.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuildtemplate.yaml
+
+## kpack
+gsutil cp -a public-read riff-application-clusterbuilder.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuilder-${slug}.yaml
+gsutil cp -a public-read riff-application-clusterbuilder.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuilder-${version}.yaml
+gsutil cp -a public-read riff-application-clusterbuilder.yaml gs://projectriff/riff-buildtemplate/riff-application-clusterbuilder.yaml
 
 # update version references
 echo "Publish builder references"

--- a/riff-application-clusterbuilder.yaml
+++ b/riff-application-clusterbuilder.yaml
@@ -1,0 +1,6 @@
+apiVersion: build.pivotal.io/v1alpha1
+kind: ClusterBuilder
+metadata:
+  name: riff-application
+spec:
+  image: cloudfoundry/cnb:0.0.5-bionic

--- a/riff-function-clusterbuilder.yaml
+++ b/riff-function-clusterbuilder.yaml
@@ -1,0 +1,6 @@
+apiVersion: build.pivotal.io/v1alpha1
+kind: ClusterBuilder
+metadata:
+  name: riff-function
+spec:
+  image: projectriff/builder:latest


### PR DESCRIPTION
The ClusterBuilder is the kpack equivalent of the Knative Build
ClusterBuildTemplate.

The ClusterBuildTemplates is deprecated, however, we will continue to
publish updates until riff is fully transitioned to kpack.