### PR TITLE
Keep the application clusterbuilder up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,4 @@ grab-run-image:
 
 templates:
 	./apply-template.sh builder.toml.tpl builder.toml
+	./apply-template.sh riff-application-clusterbuilder.yaml.tpl riff-application-clusterbuilder.yaml

--- a/riff-application-clusterbuilder.yaml
+++ b/riff-application-clusterbuilder.yaml
@@ -1,6 +1,7 @@
+# DO NOT EDIT - this file is the output of the 'riff-application-clusterbuilder.yaml.tpl' template 
 apiVersion: build.pivotal.io/v1alpha1
 kind: ClusterBuilder
 metadata:
   name: riff-application
 spec:
-  image: cloudfoundry/cnb:0.0.5-bionic
+  image: cloudfoundry/cnb:0.0.24-bionic

--- a/riff-application-clusterbuilder.yaml.tpl
+++ b/riff-application-clusterbuilder.yaml.tpl
@@ -1,0 +1,6 @@
+apiVersion: build.pivotal.io/v1alpha1
+kind: ClusterBuilder
+metadata:
+  name: riff-application
+spec:
+  image: cloudfoundry/cnb:`curl https://hub.docker.com/v2/repositories/cloudfoundry/cnb/tags | jq -r '.results[].name' | grep '\-bionic' | head -1`


### PR DESCRIPTION
This looks for the first cloudfoundry/cnb image tag that ends with
`-bionic`. It's crude, but works (for now anyway)