### PR TITLE
Pin lifecycle

### DIFF
--- a/builder-dev.toml.tpl
+++ b/builder-dev.toml.tpl
@@ -42,6 +42,9 @@ group = [
   { id = "io.projectriff.command" },
 ]
 
+[lifecycle]
+version = "0.7.2"
+
 [stack]
 id          = "io.buildpacks.stacks.bionic"
 build-image = "cloudfoundry/build:base-cnb"

--- a/builder.toml.tpl
+++ b/builder.toml.tpl
@@ -43,6 +43,9 @@ group = [
  { id = "io.projectriff.command" },
 ]
 
+[lifecycle]
+version = "0.7.2"
+
 [stack]
 id          = "io.buildpacks.stacks.bionic"
 build-image = "cloudfoundry/build:base-cnb"

--- a/builder.toml.tpl.tpl
+++ b/builder.toml.tpl.tpl
@@ -42,6 +42,9 @@ group = [
  { id = "io.projectriff.command" },
 ]
 
+[lifecycle]
+version = "0.7.2"
+
 [stack]
 id          = "io.buildpacks.stacks.bionic"
 build-image = "cloudfoundry/build:base-cnb"


### PR DESCRIPTION
* don't depend on pack's default lifecycle
* bump to newest lifecycle release
* pin instead of adding dependabot updates so the platform API compatibility w/ kpack can be managed
* update buildpacks while we are at it