### PR TITLE
pack 0.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILDER ?= projectriff/builder:dev-$(shell openssl dgst -md5 builder.toml | cut 
 .PHONY: build test
 
 build:
-	$(PACK) create-builder -b builder.toml $(BUILDER)
+	$(PACK) create-builder -c builder.toml $(BUILDER)
 
 test:
 	BUILDER=$(BUILDER) go test -v -tags=acceptance -count=1 ./acceptance


### PR DESCRIPTION
pack 0.13.0 removed some deprecated flags.  This change updates the build to use the new flags.
