### PR TITLE
Pull Request Target

### DIFF
--- a/.github/workflows/minimal-labels.yml
+++ b/.github/workflows/minimal-labels.yml
@@ -1,6 +1,6 @@
 name: Minimal Labels
 "on":
-    pull_request:
+    pull_request_target:
         types:
             - synchronize
             - reopened

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 "on":
-    pull_request: {}
+    pull_request_target: {}
     push:
         branches:
             - main

--- a/.github/workflows/update-bellsoft-liberica.yml
+++ b/.github/workflows/update-bellsoft-liberica.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-command-function.yml
+++ b/.github/workflows/update-command-function.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-java-function.yml
+++ b/.github/workflows/update-java-function.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-leiningen.yml
+++ b/.github/workflows/update-leiningen.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-node-function.yml
+++ b/.github/workflows/update-node-function.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-sbt.yml
+++ b/.github/workflows/update-sbt.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \

--- a/.github/workflows/update-streaming-http-adapter.yml
+++ b/.github/workflows/update-streaming-http-adapter.yml
@@ -62,7 +62,7 @@ jobs:
                 NEW_VERSION=$(crane ls "${DEPENDENCY}" | grep -v latest | sort -V | tail -n 1)
 
                 if [[ -e builder.toml ]]; then
-                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < builder.toml | jq -r ".buildpacks[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --builder-toml builder.toml \
@@ -71,7 +71,7 @@ jobs:
 
                   git add builder.toml
                 elif [[ -e package.toml ]]; then
-                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | select( . != null ) | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
+                  OLD_VERSION=$(yj -tj < package.toml | jq -r ".dependencies[].image | capture(\"${DEPENDENCY}:(?<version>.+)\") | .version")
 
                   update-package-dependency \
                     --buildpack-toml buildpack.toml \


### PR DESCRIPTION
Previously, the actions tied to pull requests executed on the pull_request event, which resulted in them not having access to the secrets required for them to execute.  At the beginning of August, GitHub added the pull_request_target event which operates in a similar way except only actions in the base commit would execute ensuring that it was safe to expose secrets. This change updates the pull request actions to use pull_request_target, ensuring that they are always functional.