### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-bellsoft-liberica.yml
+++ b/.github/workflows/update-bellsoft-liberica.yml
@@ -1,7 +1,7 @@
 name: Update bellsoft-liberica
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-build-image.yml
+++ b/.github/workflows/update-build-image.yml
@@ -1,7 +1,7 @@
 name: Update Build Image
 "on":
     schedule:
-        - cron: 15 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-command-function.yml
+++ b/.github/workflows/update-command-function.yml
@@ -1,7 +1,7 @@
 name: Update command-function
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-gradle.yml
+++ b/.github/workflows/update-gradle.yml
@@ -1,7 +1,7 @@
 name: Update gradle
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-java-function.yml
+++ b/.github/workflows/update-java-function.yml
@@ -1,7 +1,7 @@
 name: Update java-function
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-leiningen.yml
+++ b/.github/workflows/update-leiningen.yml
@@ -1,7 +1,7 @@
 name: Update leiningen
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-lifecycle.yml
+++ b/.github/workflows/update-lifecycle.yml
@@ -1,7 +1,7 @@
 name: Update Lifecycle
 "on":
     schedule:
-        - cron: 15 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -1,7 +1,7 @@
 name: Update maven
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-node-function.yml
+++ b/.github/workflows/update-node-function.yml
@@ -1,7 +1,7 @@
 name: Update node-function
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-nodejs.yml
+++ b/.github/workflows/update-nodejs.yml
@@ -1,7 +1,7 @@
 name: Update nodejs
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-sbt.yml
+++ b/.github/workflows/update-sbt.yml
@@ -1,7 +1,7 @@
 name: Update sbt
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-streaming-http-adapter.yml
+++ b/.github/workflows/update-streaming-http-adapter.yml
@@ -1,7 +1,7 @@
 name: Update streaming-http-adapter
 "on":
     schedule:
-        - cron: 0 * * * *
+        - cron: 0 12-23 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.