### PR TITLE
Bump lifecycle from 0.9.2 to 0.9.3

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -35,7 +35,7 @@ group = [
 ]
 
 [lifecycle]
-uri = "https://github.com/buildpacks/lifecycle/releases/download/v0.9.2/lifecycle-v0.9.2+linux.x86-64.tgz"
+uri = "https://github.com/buildpacks/lifecycle/releases/download/v0.9.3/lifecycle-v0.9.3+linux.x86-64.tgz"
 
 [stack]
 id          = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
Bumps `lifecycle` from `0.9.2` to `0.9.3`.